### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ FastAPI-based asynchronous web service that summarizes text content from URLs us
    ```bash
    docker compose up -d --build
    ```
+   or for pre-built images
+   ```bash
+   docker compose up -d
+   ```
 
 2. **Access the API**:
    - API Base URL: `http://localhost:8000`


### PR DESCRIPTION
Add docker-compose option without build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded Quick Start with an alternative path for using pre-built container images, including a ready-to-run `docker compose up -d` command.
  * Clarifies setup for users who prefer not to build locally, reducing onboarding time and simplifying initial deployment.
  * No changes to app behavior or interfaces; this update is purely textual guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->